### PR TITLE
IS-114 update interface loop to skip unassigned

### DIFF
--- a/build_page.py
+++ b/build_page.py
@@ -440,6 +440,8 @@ def build_env(e):
         # Some information can only be retrieved from interfaces
         # This is how we determine if VPN is India or US
         for i in v.interfaces:
+            if (str(i.hostname) == "None" ):
+                continue
             vm_hostname = i.hostname
             int_data = json.loads(i.json())
             # VPN: India or US?

--- a/skytapdns/main.py
+++ b/skytapdns/main.py
@@ -27,6 +27,8 @@ def recreate_all_vm_dns(e):
 
     for v in e.vms:
         for i in v.interfaces:
+            if (str(i.hostname) == "None" ):
+                continue
             vm_hostname = i.hostname
             int_data = json.loads(i.json())
             try:


### PR DESCRIPTION
update to the loop of network interfaces so the unconnected that do not have a hostname are bypassed avoiding unnecessary attempt to make a host name A record, or CNAME record for DNS